### PR TITLE
add "install" npm script to run dockerized npm i

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  dev:
+    image: node:12
+    working_dir: /usr/src/app
+    volumes:
+      - .:/usr/src/app

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,8 +1,0 @@
-version: '3'
-
-services:
-  dev:
-    image: node:12
-    working_dir: /usr/src/app
-    volumes:
-      - .:/usr/src/app

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: '3'
 
 services:
   test:
@@ -27,7 +27,7 @@ services:
       - 5432
     command: postgres -D /run/pgsql-10.4-data -F
     environment:
-      LOGGING_COLLECTOR: "on"
+      LOGGING_COLLECTOR: 'on'
       PGDATA: /run/pgsql-10.4-data
       POSTGRES_DB: api-test-db
       POSTGRES_PASSWORD: password

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "ts-node src/index.ts",
     "test": "mocha --require ts-node/register --recursive ./src/**/*.test.ts",
     "test-watch": "npm test -- -b --watch --watch-files src",
+    "install": "docker-compose -f docker-compose.dev.yml run --rm dev npm i",
     "dtw": "docker-compose -f docker-compose.test.yml run --rm test",
     "dsa": "docker stop $(docker ps -q) || true && docker rm $(docker ps -aq) || true",
     "build": "tsc"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "ts-node src/index.ts",
     "test": "mocha --require ts-node/register --recursive ./src/**/*.test.ts",
     "test-watch": "npm test -- -b --watch --watch-files src",
-    "install": "docker-compose -f docker-compose.dev.yml run --rm dev npm i",
+    "install": "docker-compose -f docker-compose.test.yml run --rm test npm i",
     "dtw": "docker-compose -f docker-compose.test.yml run --rm test",
     "dsa": "docker stop $(docker ps -q) || true && docker rm $(docker ps -aq) || true",
     "build": "tsc"


### PR DESCRIPTION
Added "install" script on package.json to ensure that `npm i` is executed from inside the container, not from the host.
This will be part of the "contributing" process, before running the unit tests.